### PR TITLE
fixing dependency on rails 5

### DIFF
--- a/plutus.gemspec
+++ b/plutus.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "LICENSE",
     "README.markdown"
   ]
-  s.add_dependency('rails',           '5.0.0')
+  s.add_dependency('rails',           '~> 5.0')
   s.add_dependency('jquery-rails',    '~> 4.1', '>= 4.1.1')
   s.add_dependency('jquery-ui-rails', '~> 5.0', '>= 5.0.5')
   s.add_development_dependency("yard")


### PR DESCRIPTION
Version number was too precise - allowed for bugfixes in rails 5
